### PR TITLE
all: use gopy to generate python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# gochimithequeutils
+
+## Installation
+
+```sh
+$> go get github.com/tbellembois/gochimithequeutils/...
+```
+
+## Installation of python bindings
+
+```sh
+$> cd $GOPATH/src/github.com/tbellembois/gochimithequeutils
+$> go generate
+
+$> export GODEBUG=cgocheck=0
+$> python
+>>> import chimitheque as ch
+>>> print(ch.__doc__)
+Package chimitheque provides useful chemistry related utilities.
+
+>>> ch.LinearToEmpiricalFormula("CH3")
+'CH3'
+
+```

--- a/generate.go
+++ b/generate.go
@@ -1,0 +1,5 @@
+package gochimithequeutils
+
+//go:generate go get -u -v github.com/go-python/gopy
+//go:generate go get ./chimitheque
+//go:generate gopy bind -lang=cffi ./chimitheque


### PR DESCRIPTION
This CL breaks gochimithequeutils into 2 parts:

- the pure Go part, renamed as gochimithequeutils/chimitheque
- the part that generates the python bindings from the pure Go package